### PR TITLE
Ezra/read key from file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,146 @@
 version = 3
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "exploring-database-tech"
 version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "libc"
+version = "0.2.155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[dev-dependencies]
+tempfile = "3.10.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,1 @@
+pub mod file;

--- a/src/common/file.rs
+++ b/src/common/file.rs
@@ -1,0 +1,41 @@
+
+use std::io::prelude::*;
+use std::fs::OpenOptions;
+use std::path::PathBuf;
+
+
+fn search_for_file(filename: &str) -> Option<PathBuf> {
+    /*
+    Searches for a filepath, and if found returns the Path object
+    if not found, returns false
+    */
+    let filepath = PathBuf::from(&format!("file_directory/{}", filename));
+    let result = filepath.try_exists().unwrap();
+    if result {
+        return Some(filepath);
+    }
+    None
+}
+
+pub fn write_to_file(filename: &str) {
+    let path = search_for_file(filename);
+    let mut open_options = OpenOptions::new();
+    open_options.create(true).append(true).read(true);
+    let mut file; 
+    match path {
+        Some(path) => {
+            println!("File found: {:?}", path);
+            file = open_options.open(path).unwrap();
+        }
+        None => {
+            println!("File not found, creating file...");
+            file = open_options.open(&format!("file_directory/{}", filename)).unwrap();
+        }
+    }
+    writeln!(file, "key: value").expect("Failed to write to file");
+
+}
+
+
+#[cfg(test)]
+mod tests;

--- a/src/common/file.rs
+++ b/src/common/file.rs
@@ -1,11 +1,12 @@
 
 use std::io::prelude::*;
+use std::io::BufReader;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 
 
 
-pub fn write_line_to_file(filepath: PathBuf, line: &str) -> Result<
+pub fn write_line_to_file(filepath: &PathBuf, line: &str) -> Result<
     (),
     std::io::Error
 > {
@@ -24,6 +25,13 @@ pub fn write_line_to_file(filepath: PathBuf, line: &str) -> Result<
     Ok(())
 }
 
+pub fn read_file_to_buffer(filepath: &PathBuf) -> BufReader<std::fs::File> {
+    /*
+    Reads a file to a buffer.  If a file does not exist, it returns an error.
+    */
+    let file = OpenOptions::new().read(true).open(filepath).expect("Failed to open file");
+    BufReader::new(file)
+}
 
 
 

--- a/src/common/file.rs
+++ b/src/common/file.rs
@@ -4,39 +4,22 @@ use std::fs::OpenOptions;
 use std::path::PathBuf;
 
 
-fn search_for_file(filename: &str, dirname: &str) -> Option<PathBuf> {
-    /*
-    Searches for a filepath within the given dirname, and if found returns the Path object
-    wrapped in Some
-    if not found, returns None
-    */
-    let filepath = PathBuf::from(&format!("{}/{}", dirname, filename));
-    let result = filepath.try_exists().unwrap();
-    if result {
-        return Some(filepath);
-    }
-    None
-}
 
-pub fn write_line_to_file(filename: &str, target_dir: &str, line: &str) -> Result<
+pub fn write_line_to_file(filepath: PathBuf, line: &str) -> Result<
     (),
     std::io::Error
 > {
-    let path = search_for_file(filename, target_dir);
-    let mut open_options = OpenOptions::new();
-    open_options.create(true).append(true).read(true);
-    let file_result: Result<std::fs::File, std::io::Error>; 
-    match path {
-        Some(path) => {
-            println!("File found: {:?}", path);
-            file_result = open_options.open(path);
-        }
-        None => {
-            println!("File not found, creating file...");
-            file_result = open_options.open(&format!("{}/{}", target_dir, filename));
-        }
+    /*
+    Appends a line to a file in the given filepath.
+    If the file does not exist, it creates the file.
+    */
+
+    if filepath.try_exists()? {
+        println!("File found at {:?}", filepath);
+    } else {
+        println!("File not found at {:?}, creating...", filepath);
     }
-    let mut file = file_result?;
+    let mut file =  OpenOptions::new().create(true).append(true).open(filepath).expect("Failed to open file");
     writeln!(file, "{}", line).expect("Failed to write to file");
     Ok(())
 }

--- a/src/common/file.rs
+++ b/src/common/file.rs
@@ -4,12 +4,13 @@ use std::fs::OpenOptions;
 use std::path::PathBuf;
 
 
-fn search_for_file(filename: &str) -> Option<PathBuf> {
+fn search_for_file(filename: &str, dirname: &str) -> Option<PathBuf> {
     /*
-    Searches for a filepath, and if found returns the Path object
-    if not found, returns false
+    Searches for a filepath within the given dirname, and if found returns the Path object
+    wrapped in Some
+    if not found, returns None
     */
-    let filepath = PathBuf::from(&format!("file_directory/{}", filename));
+    let filepath = PathBuf::from(&format!("{}/{}", dirname, filename));
     let result = filepath.try_exists().unwrap();
     if result {
         return Some(filepath);
@@ -18,7 +19,8 @@ fn search_for_file(filename: &str) -> Option<PathBuf> {
 }
 
 pub fn write_to_file(filename: &str) {
-    let path = search_for_file(filename);
+    let target_dir = "file_directory";
+    let path = search_for_file(filename, target_dir);
     let mut open_options = OpenOptions::new();
     open_options.create(true).append(true).read(true);
     let mut file; 

--- a/src/common/file.rs
+++ b/src/common/file.rs
@@ -18,8 +18,7 @@ fn search_for_file(filename: &str, dirname: &str) -> Option<PathBuf> {
     None
 }
 
-pub fn write_to_file(filename: &str) {
-    let target_dir = "file_directory";
+pub fn write_to_file(filename: &str, target_dir: &str) {
     let path = search_for_file(filename, target_dir);
     let mut open_options = OpenOptions::new();
     open_options.create(true).append(true).read(true);
@@ -31,7 +30,7 @@ pub fn write_to_file(filename: &str) {
         }
         None => {
             println!("File not found, creating file...");
-            file = open_options.open(&format!("file_directory/{}", filename)).unwrap();
+            file = open_options.open(&format!("{}/{}", target_dir, filename)).unwrap();
         }
     }
     writeln!(file, "key: value").expect("Failed to write to file");

--- a/src/common/file.rs
+++ b/src/common/file.rs
@@ -18,24 +18,30 @@ fn search_for_file(filename: &str, dirname: &str) -> Option<PathBuf> {
     None
 }
 
-pub fn write_to_file(filename: &str, target_dir: &str) {
+pub fn write_line_to_file(filename: &str, target_dir: &str, line: &str) -> Result<
+    (),
+    std::io::Error
+> {
     let path = search_for_file(filename, target_dir);
     let mut open_options = OpenOptions::new();
     open_options.create(true).append(true).read(true);
-    let mut file; 
+    let file_result: Result<std::fs::File, std::io::Error>; 
     match path {
         Some(path) => {
             println!("File found: {:?}", path);
-            file = open_options.open(path).unwrap();
+            file_result = open_options.open(path);
         }
         None => {
             println!("File not found, creating file...");
-            file = open_options.open(&format!("{}/{}", target_dir, filename)).unwrap();
+            file_result = open_options.open(&format!("{}/{}", target_dir, filename));
         }
     }
-    writeln!(file, "key: value").expect("Failed to write to file");
-
+    let mut file = file_result?;
+    writeln!(file, "{}", line).expect("Failed to write to file");
+    Ok(())
 }
+
+
 
 
 #[cfg(test)]

--- a/src/common/file/tests.rs
+++ b/src/common/file/tests.rs
@@ -1,7 +1,16 @@
-use std::fs::File;
+use std::io::BufReader;
+use std::fs::File; 
 use super::*;
 
 use tempfile::tempdir;
+
+
+fn create_temp_file(filename: &str) -> Result<(tempfile::TempDir, PathBuf), std::io::Error> {
+    let tempdir = tempdir()?;
+    let expected_path = tempdir.path().join(filename);
+    File::create(&expected_path)?;
+    Ok((tempdir, expected_path))
+}
 
 #[test]
 fn test_search_for_file_failure() {
@@ -13,16 +22,58 @@ fn test_search_for_file_failure() {
 
 #[test]
 fn test_search_for_file_success() -> std::io::Result<()> {
+    // make temp file
     let filename = "found.txt";
-
-    // make fake file
-    let tempdir = tempdir()?;
-    let expected_path = tempdir.path().join(filename);
-    File::create(&expected_path)?;
+    let (tempdir, expected_path) = create_temp_file(filename)?;
 
     // search for file
     let path = search_for_file(filename, tempdir.path().to_str().unwrap());
     assert_eq!(path, Some(expected_path));
+
+    // cleanup
+    tempdir.close()?;
+    Ok(())
+}
+
+#[test]
+fn test_write_to_file_new_file() -> std::io::Result<()> {
+    // make temp file
+    let filename = "new.txt";
+    let tempdir = tempdir()?;
+    let expected_path = tempdir.path().join(filename);
+
+    // write to file
+    write_to_file(filename, tempdir.path().to_str().unwrap());
+
+    // check file contents
+    let file = File::open(&expected_path)?;
+    let reader = BufReader::new(file);
+    let lines: Vec<String> = reader.lines().map(|l| l.unwrap()).collect();
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines, vec!["key: value"]);
+
+    // cleanup
+    tempdir.close()?;
+    Ok(())
+}
+
+
+#[test]
+fn test_write_to_file_existing_file() -> std::io::Result<()> {
+    // make temp file
+    let filename = "existing.txt";
+    let (tempdir, expected_path) = create_temp_file(filename)?;
+    
+    // write to file
+    std::fs::write(&expected_path, "key: value\n")?;
+    write_to_file(filename, tempdir.path().to_str().unwrap());
+
+    // check file contents
+    let file = File::open(&expected_path)?;
+    let reader = BufReader::new(file);
+    let lines: Vec<String> = reader.lines().map(|l| l.unwrap()).collect();
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines, vec!["key: value", "key: value"]);
 
     // cleanup
     tempdir.close()?;

--- a/src/common/file/tests.rs
+++ b/src/common/file/tests.rs
@@ -1,8 +1,30 @@
+use std::fs::File;
 use super::*;
+
+use tempfile::tempdir;
 
 #[test]
 fn test_search_for_file_failure() {
-    let filename = "foobar.txt";
-    let path = search_for_file(filename);
+    let filename = "not_found.txt";
+    let dirname = "file_directory";
+    let path = search_for_file(filename, dirname);
     assert_eq!(path, None);
+}
+
+#[test]
+fn test_search_for_file_success() -> std::io::Result<()> {
+    let filename = "found.txt";
+
+    // make fake file
+    let tempdir = tempdir()?;
+    let expected_path = tempdir.path().join(filename);
+    File::create(&expected_path)?;
+
+    // search for file
+    let path = search_for_file(filename, tempdir.path().to_str().unwrap());
+    assert_eq!(path, Some(expected_path));
+
+    // cleanup
+    tempdir.close()?;
+    Ok(())
 }

--- a/src/common/file/tests.rs
+++ b/src/common/file/tests.rs
@@ -1,0 +1,8 @@
+use super::*;
+
+#[test]
+fn test_search_for_file_failure() {
+    let filename = "foobar.txt";
+    let path = search_for_file(filename);
+    assert_eq!(path, None);
+}

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -24,11 +24,12 @@ impl KVStore {
 
 
 pub fn write_value_to_store(store: KVStore, key: &str, value: &str) -> Result<
-    bool, 
+    (),
     std::io::Error
->{
-    file::write_to_file(store.filename.as_str(), store.target_dir.as_str());
-    Ok(true)
+> {
+
+    let line = format!("{}: {}", key, value);
+    file::write_line_to_file(store.filename.as_str(), store.target_dir.as_str(), line.as_str())
 }
 
 

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1,0 +1,37 @@
+
+use crate::common::file;
+
+
+
+pub struct KVStore {
+    filename: String,
+    target_dir: String,
+    file_length: u64,
+    buffer: Vec<u8>,
+}
+
+
+impl KVStore {
+    pub fn new(filename: &str, target_dir: &str) -> Self {
+        KVStore {
+            filename: filename.to_string(),
+            target_dir: target_dir.to_string(),
+            file_length: 100, 
+            buffer: Vec::new(),
+        }
+    }
+}
+
+
+pub fn write_value_to_store(store: KVStore, key: &str, value: &str) -> Result<
+    bool, 
+    std::io::Error
+>{
+    file::write_to_file(store.filename.as_str(), store.target_dir.as_str());
+    Ok(true)
+}
+
+
+
+#[cfg(test)]
+mod tests;

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1,5 +1,10 @@
 
+use std::collections::HashMap;
+use std::path::PathBuf;
+
 use crate::common::file;
+
+
 
 
 
@@ -8,6 +13,8 @@ pub struct KVStore {
     target_dir: String,
     file_length: u64,
     buffer: Vec<u8>,
+    filepath: PathBuf,
+    data: HashMap<String, String>,
 }
 
 
@@ -18,6 +25,8 @@ impl KVStore {
             target_dir: target_dir.to_string(),
             file_length: 100, 
             buffer: Vec::new(),
+            filepath: PathBuf::from(&format!("{}/{}", target_dir, filename)),
+            data: HashMap::new(),
         }
     }
 }
@@ -29,7 +38,7 @@ pub fn write_value_to_store(store: KVStore, key: &str, value: &str) -> Result<
 > {
 
     let line = format!("{}: {}", key, value);
-    file::write_line_to_file(store.filename.as_str(), store.target_dir.as_str(), line.as_str())
+    file::write_line_to_file(store.filepath, &line)
 }
 
 

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1,12 +1,8 @@
-
 use std::collections::HashMap;
+use std::io::BufRead as _;
 use std::path::PathBuf;
 
 use crate::common::file;
-
-
-
-
 
 pub struct KVStore {
     filename: String,
@@ -17,28 +13,41 @@ pub struct KVStore {
     data: HashMap<String, String>,
 }
 
-
 impl KVStore {
     pub fn new(filename: &str, target_dir: &str) -> Self {
         KVStore {
             filename: filename.to_string(),
             target_dir: target_dir.to_string(),
-            file_length: 100, 
+            file_length: 100,
             buffer: Vec::new(),
             filepath: PathBuf::from(&format!("{}/{}", target_dir, filename)),
             data: HashMap::new(),
         }
     }
+
+
+    pub fn load(&mut self) -> Result<(), std::io::Error> {
+        let mut line = String::new();
+        let mut buffer = file::read_file_to_buffer(&self.filepath);
+        while buffer.read_line(&mut line)? > 0 {
+            let parts: Vec<&str> = line.split(":").collect();
+            self.data.insert(parts[0].to_string(), parts[1].to_string());
+            line.clear();
+        }
+        Ok(())
+    }
+
+    pub fn get_key(&self, key: &str) -> &str {
+        self.data.get(key).unwrap()
+    }
 }
 
-
-pub fn write_value_to_store(store: KVStore, key: &str, value: &str) -> Result<
-    (),
-    std::io::Error
-> {
-
+pub fn write_value_to_store(store: &KVStore, key: &str, value: &str) -> Result<(), std::io::Error> {
+    /*
+    Writes a key-value pair to the store.
+    */
     let line = format!("{}: {}", key, value);
-    file::write_line_to_file(store.filepath, &line)
+    file::write_line_to_file(&store.filepath, &line)
 }
 
 

--- a/src/kv/tests.rs
+++ b/src/kv/tests.rs
@@ -1,0 +1,20 @@
+use std::io::BufReader;
+use std::fs::File; 
+use super::*;
+
+#[test]
+fn test_set_key() -> std::io::Result<()> {
+
+    // create a database
+    // call add key method
+    // verify that the key was added to the underlying file 
+
+    let filename = "foo.kv";
+    let target_dir = "file_directory";
+    let db = KVStore::get_or_create(filename, target_dir);
+    db.set_key("10001", "{\"name\": \"John Doe\"}")?;
+    let log = db.get_log();
+    assert_eq!(log.len(), 1);
+    asssert_eq!(log[0], "10001: {\"name\": \"John Doe\"}");
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,39 +1,11 @@
-use std::fs::{OpenOptions};
-use std::path::PathBuf;
-use std::io::prelude::*;
-
-fn search_for_file(filename: &str) -> Option<PathBuf> {
-    /*
-    Searches for a filepath, and if found returns the Path object
-    if not found, returns false
-    */
-    let filepath = PathBuf::from(&format!("file_directory/{}", filename));
-    let result = filepath.try_exists().unwrap();
-    if result {
-        return Some(filepath);
-    }
-    None
-}
-
-fn main() {
-    let filename = "foo.txt";
-    let path = search_for_file(filename);
-    let mut open_options = OpenOptions::new();
-    open_options.create(true).append(true).read(true);
-    let mut file; 
-    match path {
-        Some(path) => {
-            println!("File found: {:?}", path);
-            file = open_options.open(path).unwrap();
-        }
-        None => {
-            println!("File not found, creating file...");
-            file = open_options.open(&format!("file_directory/{}", filename)).unwrap();
-        }
-    }
-    writeln!(file, "key: value").expect("Failed to write to file");
-}
-
+mod common;
 // simplest key value store database ever
 // find a file, if it doesn't exist or the current file is full, create one
 // write a key and value store to the file, then search for it and print it out
+
+fn main() {
+    let filename = "foo.txt";
+    common::file::write_to_file(filename);
+}
+
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ mod common;
 
 fn main() {
     let filename = "foo.txt";
-    common::file::write_to_file(filename);
+    let target_dir = "file_directory";
+    common::file::write_to_file(filename, target_dir);
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,10 @@ mod kv;
 fn main() {
     let filename = "foo.txt";
     let target_dir = "file_directory";
-    let store = kv::KVStore::new(filename, target_dir);
-    kv::write_value_to_store(store, "foo", "bar").expect("Failed to write to store");
+    let mut store = kv::KVStore::new(filename, target_dir);
+    kv::write_value_to_store(&store, "foo", "batz").expect("Failed to write to store");
+    store.load().expect("Failed to load store");
+    println!("{:?}", store.get_key("foo"));
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,11 @@
 mod common;
-// simplest key value store database ever
-// find a file, if it doesn't exist or the current file is full, create one
-// write a key and value store to the file, then search for it and print it out
+mod kv;
 
 fn main() {
     let filename = "foo.txt";
     let target_dir = "file_directory";
-    common::file::write_to_file(filename, target_dir);
+    let store = kv::KVStore::new(filename, target_dir);
+    kv::write_value_to_store(store, "foo", "bar");
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     let filename = "foo.txt";
     let target_dir = "file_directory";
     let store = kv::KVStore::new(filename, target_dir);
-    kv::write_value_to_store(store, "foo", "bar");
+    kv::write_value_to_store(store, "foo", "bar").expect("Failed to write to store");
 }
 
 


### PR DESCRIPTION
Very first POC to load a key's value from file.  

Interface exposes a `load` and `get_key` method.

`load` will read the source file into `HashMap` storage, and `get_key` is used to retrieve values afterward.  It's very rudimentary, to the extent that newlines aren't even eliminated:

```
cargo run
```
results in
```
File found at "file_directory/foo.txt"
" batz\n"
```